### PR TITLE
fix cross browser bugs

### DIFF
--- a/DataLineageApp/src/client/client-app-tree.ts
+++ b/DataLineageApp/src/client/client-app-tree.ts
@@ -144,6 +144,8 @@ class App {
         // adds the circle to the node
         const circle = node.append("circle")
             .attr("class", "package")
+        //although we enable css for r, but css for svg shape is supported only by chrome, so we need to explict set this again for making it work on Edge and firfox
+            .attr("r", drawConfig.nodeRadius)
             .attr("fill", d => this._packages.pacakgeColor(d.data.data.mamAddress) as string);
 
         
@@ -167,17 +169,10 @@ class App {
             txtElement.attr("dy", (rect.height / 2) * 0.6).attr("dx", -(rect.width / 2) * 0.65);
 
             d3.select(n).append("text")
+                .text(`Owner: ${pkg.ownerMetadata ? pkg.ownerMetadata : "Unkown"}`)
                 .attr("dx", drawConfig.nodeRadius * 1.5)
-                .attr("dy", drawConfig.nodeRadius * 0.5)
-                .text(`Owner: ${pkg.ownerMetadata ? pkg.ownerMetadata :"Unkown"}`);
+                .attr("dy", drawConfig.nodeRadius * 0.5);
         });
-
-        // adds the text to the node
-        //node.append("text")
-        //    .attr("dy", ".35em")
-        //    .attr("y", d => d.children ? -20 : 20)
-        //    .style("text-anchor", "middle")
-        //    .text(d => d.data.name);
     }
 
     /**

--- a/DataLineageApp/src/client/d3-package-extensions.ts
+++ b/DataLineageApp/src/client/d3-package-extensions.ts
@@ -42,10 +42,50 @@ export function packageDescriptionHtml(pkg: IDataPackage | ILightweightPackage |
 class DrawConfig {
     private _nodeRadius: number | undefined;
 
+    private hardCodeEvalCssValue(width: number): { r: number; strokeWidth: number } {
+        if (width <= 100) {
+            return {
+                r: 10,
+                strokeWidth: 7
+            };
+        } else if (width <= 576) {
+            return {
+                r: 10,
+                strokeWidth: 7
+            };
+        } else if (width <= 768) {
+            return {
+                r: 10,
+                strokeWidth: 7
+            };
+        } else if (width <= 992) {
+            return {
+                r: 15,
+                strokeWidth: 7
+            };
+        } else if (width <= 1200) {
+            return {
+                r: 16,
+                strokeWidth: 9
+            };
+        } else {
+            return {
+                r: 16,
+                strokeWidth: 9
+            };
+        }
+    }
+
     get nodeRadius() {
         //will try to get the circle.r from style (effected by css), if can't get, then will use default value of 8
-        if (this._nodeRadius) return this._nodeRadius;
+        //dynamic add/remove svg shape and applied with css only works on chrome, on Edge or firefox, this code cause exception
+        //so we change to hard code get the radius by svg width
         const $svg = $("svg");
+        if ($svg.length>0) {
+            return this.hardCodeEvalCssValue($svg.width() as number).r;
+        }
+        /*
+        if (this._nodeRadius) return this._nodeRadius;        
         if ($svg.length > 0) {
             const d3Svg = d3.select($svg[0] as any);
             const radiu = (): number | undefined => {
@@ -73,7 +113,7 @@ class DrawConfig {
             }
         }
         //8 is default value
-        
+        */
         return this._nodeRadius ? this._nodeRadius : 8;
     }
 


### PR DESCRIPTION
originally, we use css to set svg circle r and so on, but only chrome support this feature, so we manually set the attribut r for svg circle so that the tree view works on firfox and edge
the calcualtion of circle r by js with css only works on chrome, comment them and use hard code r for firefox and edge