### PR TITLE
Upgrade version of react-dom for security reason

### DIFF
--- a/DataLineageApp/package.json
+++ b/DataLineageApp/package.json
@@ -62,7 +62,7 @@
     "node-cache": "^4.2.0",
     "pug": "^2.0.0-beta6",
     "react": "^16.4.1",
-    "react-dom": "^16.4.1",
+    "react-dom": ">=16.4.2",
     "readline": "^1.3.0",
     "serve-favicon": "^2.3.0",
     "socket.io": "^2.1.1",


### PR DESCRIPTION
CVE-2018-6341
low severity
Vulnerable versions: >= 16.4.0, < 16.4.2
Patched version: 16.4.2

React applications which rendered to HTML using the ReactDOMServer API were not escaping user-supplied attribute names at render-time. That lack of escaping could lead to a cross-site scripting vulnerability. This vulnerability can only affect some server-rendered React apps. Purely client-rendered apps are not affected.

This issue affected minor releases 16.0.x, 16.1.x, 16.2.x, 16.3.x, and 16.4.x. It was fixed in 16.0.1, 16.1.2, 16.2.1, 16.3.3, and 16.4.2